### PR TITLE
Player state does not updated sometime

### DIFF
--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
@@ -150,6 +150,8 @@ public class BackgroundAudioPlayer implements AudioPlayer {
         if (repeatMode) {
             player.setRepeatMode(player.REPEAT_MODE_ALL);
         }
+        initEventListeners();
+        player.setPlayWhenReady(true);
     }
 
     @Override
@@ -161,8 +163,6 @@ public class BackgroundAudioPlayer implements AudioPlayer {
 
             this.audioObject = audioObject;
             this.initExoPlayer(0);
-            initEventListeners();
-            player.setPlayWhenReady(true);
         }
     }
 
@@ -175,8 +175,6 @@ public class BackgroundAudioPlayer implements AudioPlayer {
 
             this.audioObjects = audioObjects;
             this.initExoPlayer(index);
-            initEventListeners();
-            player.setPlayWhenReady(true);
         }
     }
 
@@ -212,8 +210,6 @@ public class BackgroundAudioPlayer implements AudioPlayer {
             } else {
                 this.stopped = false;
                 this.initExoPlayer(0);
-                initEventListeners();
-                player.setPlayWhenReady(true);
             }
         }
     }

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
@@ -150,8 +150,6 @@ public class BackgroundAudioPlayer implements AudioPlayer {
         if (repeatMode) {
             player.setRepeatMode(player.REPEAT_MODE_ALL);
         }
-        initEventListeners();
-        player.setPlayWhenReady(true);
     }
 
     @Override
@@ -163,6 +161,8 @@ public class BackgroundAudioPlayer implements AudioPlayer {
 
             this.audioObject = audioObject;
             this.initExoPlayer(0);
+            initEventListeners();
+            player.setPlayWhenReady(true);
         }
     }
 
@@ -175,6 +175,8 @@ public class BackgroundAudioPlayer implements AudioPlayer {
 
             this.audioObjects = audioObjects;
             this.initExoPlayer(index);
+            initEventListeners();
+            player.setPlayWhenReady(true);
         }
     }
 
@@ -210,6 +212,8 @@ public class BackgroundAudioPlayer implements AudioPlayer {
             } else {
                 this.stopped = false;
                 this.initExoPlayer(0);
+                initEventListeners();
+                player.setPlayWhenReady(true);
             }
         }
     }

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
@@ -3,6 +3,7 @@ package danielr2001.audioplayer.audioplayers;
 import android.app.Activity;
 import android.content.Context;
 import android.net.Uri;
+import android.os.Handler;
 import android.util.Log;
 import android.view.Surface;
 import android.webkit.URLUtil;
@@ -161,8 +162,13 @@ public class BackgroundAudioPlayer implements AudioPlayer {
 
             this.audioObject = audioObject;
             this.initExoPlayer(0);
-            initEventListeners();
-            player.setPlayWhenReady(true);
+            new Handler().postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    initEventListeners();
+                    player.setPlayWhenReady(true);
+                }
+            }, 4000);
         }
     }
 
@@ -175,8 +181,13 @@ public class BackgroundAudioPlayer implements AudioPlayer {
 
             this.audioObjects = audioObjects;
             this.initExoPlayer(index);
-            initEventListeners();
-            player.setPlayWhenReady(true);
+            new Handler().postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    initEventListeners();
+                    player.setPlayWhenReady(true);
+                }
+            }, 4000);
         }
     }
 
@@ -212,8 +223,13 @@ public class BackgroundAudioPlayer implements AudioPlayer {
             } else {
                 this.stopped = false;
                 this.initExoPlayer(0);
-                initEventListeners();
-                player.setPlayWhenReady(true);
+                new Handler().postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        initEventListeners();
+                        player.setPlayWhenReady(true);
+                    }
+                }, 4000);
             }
         }
     }

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
@@ -529,8 +529,8 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
                             if (mediaNotificationManager.isShowing()) {
                                 mediaNotificationManager.makeNotification(true);
                             }
-                            ref.handlePositionUpdates();
                             ref.handleStateChange(foregroundAudioPlayer, PlayerState.PLAYING);
+                            ref.handlePositionUpdates();
                         } else if (!playWhenReady) {
                             // paused
                             playing = false;

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
@@ -285,14 +285,14 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
 
             this.audioObject = audioObject;
             this.initExoPlayer(0);
-            final Handler handler = new Handler();
-            handler.postDelayed(new Runnable() {
+
+            new Handler().postDelayed(new Runnable() {
                 @Override
                 public void run() {
                     initEventListeners();
                     player.setPlayWhenReady(true);
                 }
-            }, 5000);
+            }, 4000);
         }
     }
 
@@ -305,8 +305,13 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
 
             this.audioObjects = audioObjects;
             this.initExoPlayer(index);
-            initEventListeners();
-            player.setPlayWhenReady(true);
+            new Handler().postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    initEventListeners();
+                    player.setPlayWhenReady(true);
+                }
+            }, 4000);
         }
     }
 
@@ -343,8 +348,13 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
             } else {
                 this.stopped = false;
                 this.initExoPlayer(0);
-                initEventListeners();
-                player.setPlayWhenReady(true);
+                new Handler().postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        initEventListeners();
+                        player.setPlayWhenReady(true);
+                    }
+                }, 4000);
             }
         }
     }

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
@@ -274,6 +274,8 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
         if (repeatMode) {
             player.setRepeatMode(player.REPEAT_MODE_ALL);
         }
+        initEventListeners();
+        player.setPlayWhenReady(true);
     }
 
     @Override
@@ -285,14 +287,6 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
 
             this.audioObject = audioObject;
             this.initExoPlayer(0);
-            final Handler handler = new Handler();
-            handler.postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    initEventListeners();
-                    player.setPlayWhenReady(true);
-                }
-            }, 5000);
         }
     }
 
@@ -305,8 +299,6 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
 
             this.audioObjects = audioObjects;
             this.initExoPlayer(index);
-            initEventListeners();
-            player.setPlayWhenReady(true);
         }
     }
 
@@ -343,8 +335,6 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
             } else {
                 this.stopped = false;
                 this.initExoPlayer(0);
-                initEventListeners();
-                player.setPlayWhenReady(true);
             }
         }
     }

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
@@ -11,6 +11,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Binder;
 import android.os.Build;
+import android.os.Handler;
 import android.os.IBinder;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.util.Log;
@@ -284,8 +285,14 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
 
             this.audioObject = audioObject;
             this.initExoPlayer(0);
-            initEventListeners();
-            player.setPlayWhenReady(true);
+            final Handler handler = new Handler();
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    initEventListeners();
+                    player.setPlayWhenReady(true);
+                }
+            }, 5000);
         }
     }
 

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
@@ -274,8 +274,6 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
         if (repeatMode) {
             player.setRepeatMode(player.REPEAT_MODE_ALL);
         }
-        initEventListeners();
-        player.setPlayWhenReady(true);
     }
 
     @Override
@@ -287,6 +285,14 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
 
             this.audioObject = audioObject;
             this.initExoPlayer(0);
+            final Handler handler = new Handler();
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    initEventListeners();
+                    player.setPlayWhenReady(true);
+                }
+            }, 5000);
         }
     }
 
@@ -299,6 +305,8 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
 
             this.audioObjects = audioObjects;
             this.initExoPlayer(index);
+            initEventListeners();
+            player.setPlayWhenReady(true);
         }
     }
 
@@ -335,6 +343,8 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
             } else {
                 this.stopped = false;
                 this.initExoPlayer(0);
+                initEventListeners();
+                player.setPlayWhenReady(true);
             }
         }
     }


### PR DESCRIPTION
**Issue:** Player state playing is not called some time in slow devices like in emulators 

**Reason of issue:** We have set event listener immediately before exoplayer initialised

**Solution:** Set all event listener after some time when exoplayer is initialised

**Side Effect:** There will be no side-effect.

**Note:** `onPlayerStateChanged` is not called some time because we have immediately add listener to player object so in flutter side `PlayerState.Playing` is not called so it will create a problem.
Also i am put `initEventListeners();` method inside this method  `initExoPlayer()` but it is not worked.