### PR TITLE
Hide next previous and handle rewind forward buttons in notification bar

### DIFF
--- a/android/src/main/java/danielr2001/audioplayer/AudioPlayerPlugin.java
+++ b/android/src/main/java/danielr2001/audioplayer/AudioPlayerPlugin.java
@@ -175,6 +175,10 @@ public class AudioPlayerPlugin implements MethodCallHandler {
               notificationDefaultActions = NotificationDefaultActions.NEXT;
             } else if (notificationDefaultActionsInt == 2){
               notificationDefaultActions = NotificationDefaultActions.PREVIOUS;
+            } else if (notificationDefaultActionsInt == 3){
+              notificationDefaultActions = NotificationDefaultActions.FORWARD;
+            } else if (notificationDefaultActionsInt == 4){
+              notificationDefaultActions = NotificationDefaultActions.BACKWARD;
             }else{
               notificationDefaultActions = NotificationDefaultActions.ALL;
             }
@@ -253,6 +257,10 @@ public class AudioPlayerPlugin implements MethodCallHandler {
                 notificationDefaultActions = NotificationDefaultActions.NEXT;
               } else if (notificationDefaultActionsInts.get(i) == 2){
                 notificationDefaultActions = NotificationDefaultActions.PREVIOUS;
+              } else if (notificationDefaultActionsInts.get(i) == 4){
+                notificationDefaultActions = NotificationDefaultActions.FORWARD;
+              } else if (notificationDefaultActionsInts.get(i) == 5){
+                notificationDefaultActions = NotificationDefaultActions.BACKWARD;
               }else{
                 notificationDefaultActions = NotificationDefaultActions.ALL;
               }
@@ -381,6 +389,12 @@ public class AudioPlayerPlugin implements MethodCallHandler {
           break;
         case CUSTOM2:
           channel.invokeMethod("audio.onNotificationActionCallback",buildArguments(audioplayer.getPlayerId(), 5));  
+          break;
+        case FORWARD:
+          channel.invokeMethod("audio.onNotificationActionCallback",buildArguments(audioplayer.getPlayerId(), 6));
+          break;
+        case BACKWARD:
+          channel.invokeMethod("audio.onNotificationActionCallback",buildArguments(audioplayer.getPlayerId(), 7));
           break;
       }
   }

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
@@ -150,6 +150,28 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
                                 NotificationActionName.NEXT);
                     }
                     break;
+                case MediaNotificationManager.FORWARD_ACTION:
+                    if (currentAudioObject.getNotificationActionCallbackMode() == NotificationActionCallbackMode.DEFAULT) {
+                        if(!this.released){
+                            player.seekTo(player.getCurrentPosition() + 15000);
+                        }
+                    } else {
+                        ref.handleNotificationActionCallback(this.foregroundAudioPlayer, NotificationActionName.FORWARD);
+                    }
+                    break;
+                case MediaNotificationManager.BACKWARD_ACTION:
+                    if (currentAudioObject.getNotificationActionCallbackMode() == NotificationActionCallbackMode.DEFAULT) {
+                        if(!this.released){
+                            if(player.getCurrentPosition()>=15000){
+                                player.seekTo(player.getCurrentPosition() - 15000);
+                            }else{
+                                player.seekTo(0);
+                            }
+                        }
+                    }else{
+                        ref.handleNotificationActionCallback(this.foregroundAudioPlayer, NotificationActionName.BACKWARD);
+                    }
+                    break;
                 case MediaNotificationManager.CUSTOM1_ACTION:
                     ref.handleNotificationActionCallback(this.foregroundAudioPlayer,
                             NotificationActionName.CUSTOM1);

--- a/android/src/main/java/danielr2001/audioplayer/enums/NotificationActionName.java
+++ b/android/src/main/java/danielr2001/audioplayer/enums/NotificationActionName.java
@@ -7,4 +7,6 @@ public enum NotificationActionName {
     PAUSE,
     CUSTOM1,
     CUSTOM2,
+    FORWARD,
+    BACKWARD,
 }

--- a/android/src/main/java/danielr2001/audioplayer/enums/NotificationDefaultActions.java
+++ b/android/src/main/java/danielr2001/audioplayer/enums/NotificationDefaultActions.java
@@ -5,4 +5,6 @@ public enum NotificationDefaultActions {
     NEXT,
     PREVIOUS,
     ALL,
+    FORWARD,
+    BACKWARD,
 }

--- a/android/src/main/java/danielr2001/audioplayer/notifications/MediaNotificationManager.java
+++ b/android/src/main/java/danielr2001/audioplayer/notifications/MediaNotificationManager.java
@@ -14,7 +14,6 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.support.v4.media.session.MediaSessionCompat;
@@ -31,6 +30,8 @@ public class MediaNotificationManager {
     public static final String NEXT_ACTION = "com.daniel.exoPlayer.action.next";
     public static final String CUSTOM1_ACTION = "com.daniel.exoPlayer.action.custom1";
     public static final String CUSTOM2_ACTION = "com.daniel.exoPlayer.action.custom2";
+    public static final String FORWARD_ACTION = "com.daniel.exoPlayer.action.forward";
+    public static final String BACKWARD_ACTION = "com.daniel.exoPlayer.action.backward";
     public static final int NOTIFICATION_ID = 1;
     public static final String CHANNEL_ID = "Playback";
 
@@ -48,6 +49,8 @@ public class MediaNotificationManager {
     private Intent notificationIntent;
     private Intent customIntent1;
     private Intent customIntent2;
+    private Intent forwardIntent;
+    private Intent backwardIntent;
 
     private PendingIntent ppPlayIntent;
     private PendingIntent pPauseIntent;
@@ -56,6 +59,8 @@ public class MediaNotificationManager {
     private PendingIntent pNotificatioIntent;
     private PendingIntent pCustomIntent1;
     private PendingIntent pCustomIntent2;
+    private PendingIntent pForwardIntent;
+    private PendingIntent pBackwardIntent;
 
     private AudioObject audioObject;
     private boolean isPlaying;
@@ -116,6 +121,14 @@ public class MediaNotificationManager {
         customIntent2 = new Intent(this.context, ForegroundAudioPlayer.class);
         customIntent2.setAction(CUSTOM2_ACTION);
         pCustomIntent2 = PendingIntent.getService(this.context, 1, customIntent2, 0);
+
+        forwardIntent = new Intent(this.context, ForegroundAudioPlayer.class);
+        forwardIntent.setAction(FORWARD_ACTION);
+        pForwardIntent = PendingIntent.getService(this.context, 1, forwardIntent, 0);
+
+        backwardIntent = new Intent(this.context, ForegroundAudioPlayer.class);
+        backwardIntent.setAction(BACKWARD_ACTION);
+        pBackwardIntent = PendingIntent.getService(this.context, 1, backwardIntent, 0);
 
     }
 
@@ -209,7 +222,13 @@ public class MediaNotificationManager {
             builder.addAction(customIcon1, "Custom1", pCustomIntent1);
         }
         if (audioObject.getNotificationActionMode() == NotificationDefaultActions.PREVIOUS || audioObject.getNotificationActionMode() == NotificationDefaultActions.ALL) {
-            builder.addAction(R.drawable.ic_previous, "Previous", pPrevIntent);
+            //builder.addAction(R.drawable.ic_previous, "Previous", pPrevIntent);
+        }
+
+        if (audioObject.getNotificationActionMode() == NotificationDefaultActions.FORWARD ||
+                audioObject.getNotificationActionMode() == NotificationDefaultActions.BACKWARD ||
+                audioObject.getNotificationActionMode() == NotificationDefaultActions.ALL) {
+            builder.addAction(R.drawable.exo_icon_rewind, "Backward", pBackwardIntent);
         }
 
         if (this.isPlaying) {
@@ -218,8 +237,14 @@ public class MediaNotificationManager {
             builder.addAction(R.drawable.ic_play, "Play", ppPlayIntent);
         }
 
+        if (audioObject.getNotificationActionMode() == NotificationDefaultActions.FORWARD ||
+                audioObject.getNotificationActionMode() == NotificationDefaultActions.BACKWARD ||
+                audioObject.getNotificationActionMode() == NotificationDefaultActions.ALL) {
+            builder.addAction(R.drawable.exo_icon_fastforward, "Forward", pForwardIntent);
+        }
+
         if (audioObject.getNotificationActionMode() == NotificationDefaultActions.NEXT || audioObject.getNotificationActionMode() == NotificationDefaultActions.ALL) {
-            builder.addAction(R.drawable.ic_next, "Next", pNextIntent);
+            //builder.addAction(R.drawable.ic_next, "Next", pNextIntent);
         }
         if(audioObject.getNotificationCustomActions() == NotificationCustomActions.TWO){
             builder.addAction(customIcon2, "Custom2", pCustomIntent2);
@@ -229,7 +254,9 @@ public class MediaNotificationManager {
 
     private NotificationCompat.Builder initNotificationStyle(NotificationCompat.Builder builder) {
         if (audioObject.getNotificationActionMode() == NotificationDefaultActions.NEXT
-                || audioObject.getNotificationActionMode() == NotificationDefaultActions.PREVIOUS) {
+                || audioObject.getNotificationActionMode() == NotificationDefaultActions.PREVIOUS
+                || audioObject.getNotificationActionMode() == NotificationDefaultActions.FORWARD
+                || audioObject.getNotificationActionMode() == NotificationDefaultActions.BACKWARD) {
             builder.setStyle(new androidx.media.app.NotificationCompat.DecoratedMediaCustomViewStyle()
                     .setShowActionsInCompactView(0, 1)
                     .setMediaSession(mediaSession.getSessionToken()));


### PR DESCRIPTION
Issue: Hide next previous and handle rewind forward buttons in notification bar

Solution: Hide next previous for now and handle rewind forward buttons for premium users in notification bar

Side Effect: There will be no side-effect.