### PR TITLE
Player stop working when applied seek to position

### DIFF
--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
@@ -248,6 +248,7 @@ public class BackgroundAudioPlayer implements AudioPlayer {
     public void seekPosition(int position) {
         if (!this.released) {
             player.seekTo(player.getCurrentWindowIndex(), position);
+            player.setPlayWhenReady(true);
         }
     }
 

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
@@ -401,6 +401,7 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
     public void seekPosition(int position) {
         if (!this.released) {
             player.seekTo(player.getCurrentWindowIndex(), position);
+            player.setPlayWhenReady(true);
         }
     }
 


### PR DESCRIPTION
**Issue:** When we use seek to position while player is in buffering state player is stopped working

**Reason of issue:** Not set flag setPlayWhenReady 

**Solution:** Set flag setPlayWhenReady true when we use seek to position

**Side Effect:** There will be no side-effect.