### PR TITLE
Fixed #2203 Add error policy to reconnect exoplayer

### DIFF
--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
@@ -74,7 +74,7 @@ public class BackgroundAudioPlayer implements AudioPlayer {
     private ArrayList<AudioObject> audioObjects;
     private AudioObject audioObject;
     private Cache cache;
-
+    private InsightCustomLoadErrorPolicy insightCustomLoadErrorPolicy;
 
     @Override
     public void initAudioPlayer(AudioPlayerPlugin ref, Activity activity, String playerId) {
@@ -108,6 +108,7 @@ public class BackgroundAudioPlayer implements AudioPlayer {
         DataSource.Factory offlineDataSourceFactory = new DefaultDataSourceFactory(this.context, Util.getUserAgent(this.context, "exoPlayerLibrary"));
         DataSource.Factory onlineDataSourceFactory = new InsightCacheDataSourceFactory(this.context, cache);
         // playlist/single audio load
+        insightCustomLoadErrorPolicy = new InsightCustomLoadErrorPolicy();
         if (playerMode == PlayerMode.PLAYLIST) {
             ConcatenatingMediaSource concatenatingMediaSource = new ConcatenatingMediaSource();
             for (AudioObject audioObject : audioObjects) {
@@ -115,9 +116,11 @@ public class BackgroundAudioPlayer implements AudioPlayer {
                 MediaSource mediaSource;
                 if (URLUtil.isHttpsUrl(url) || URLUtil.isHttpUrl(url)) {
                     mediaSource = new ProgressiveMediaSource.Factory(onlineDataSourceFactory)
+                            .setLoadErrorHandlingPolicy(insightCustomLoadErrorPolicy)
                             .createMediaSource(Uri.parse(url));
                 } else {
                     mediaSource = new ProgressiveMediaSource.Factory(offlineDataSourceFactory)
+                            .setLoadErrorHandlingPolicy(insightCustomLoadErrorPolicy)
                             .createMediaSource(Uri.parse(url));
                 }
                 concatenatingMediaSource.addMediaSource(mediaSource);
@@ -131,9 +134,11 @@ public class BackgroundAudioPlayer implements AudioPlayer {
             MediaSource mediaSource;
             if (URLUtil.isHttpsUrl(url) || URLUtil.isHttpUrl(url)) {
                 mediaSource = new ProgressiveMediaSource.Factory(onlineDataSourceFactory)
+                        .setLoadErrorHandlingPolicy(insightCustomLoadErrorPolicy)
                         .createMediaSource(Uri.parse(url));
             } else {
                 mediaSource = new ProgressiveMediaSource.Factory(offlineDataSourceFactory)
+                        .setLoadErrorHandlingPolicy(insightCustomLoadErrorPolicy)
                         .createMediaSource(Uri.parse(url));
             }
             player.prepare(mediaSource, true, false);

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
@@ -74,7 +74,6 @@ public class BackgroundAudioPlayer implements AudioPlayer {
     private ArrayList<AudioObject> audioObjects;
     private AudioObject audioObject;
     private Cache cache;
-    private InsightCustomLoadErrorPolicy insightCustomLoadErrorPolicy;
 
     @Override
     public void initAudioPlayer(AudioPlayerPlugin ref, Activity activity, String playerId) {
@@ -108,7 +107,7 @@ public class BackgroundAudioPlayer implements AudioPlayer {
         DataSource.Factory offlineDataSourceFactory = new DefaultDataSourceFactory(this.context, Util.getUserAgent(this.context, "exoPlayerLibrary"));
         DataSource.Factory onlineDataSourceFactory = new InsightCacheDataSourceFactory(this.context, cache);
         // playlist/single audio load
-        insightCustomLoadErrorPolicy = new InsightCustomLoadErrorPolicy();
+        InsightCustomLoadErrorPolicy insightCustomLoadErrorPolicy = new InsightCustomLoadErrorPolicy();
         if (playerMode == PlayerMode.PLAYLIST) {
             ConcatenatingMediaSource concatenatingMediaSource = new ConcatenatingMediaSource();
             for (AudioObject audioObject : audioObjects) {

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
@@ -90,6 +90,7 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
     private ArrayList<AudioObject> audioObjects;
     private AudioObject audioObject;
     private Cache cache;
+    private InsightCustomLoadErrorPolicy insightCustomLoadErrorPolicy;
 
     @Nullable
     @Override
@@ -274,6 +275,7 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
         DataSource.Factory offlineDataSourceFactory = new DefaultDataSourceFactory(this, Util.getUserAgent(this.context, "exoPlayerLibrary"));
         DataSource.Factory onlineDataSourceFactory = new InsightCacheDataSourceFactory(this.context, cache);
         // playlist/single audio load
+        insightCustomLoadErrorPolicy = new InsightCustomLoadErrorPolicy();
         if (this.playerMode == PlayerMode.PLAYLIST) {
             ConcatenatingMediaSource concatenatingMediaSource = new ConcatenatingMediaSource();
             for (AudioObject audioObject : audioObjects) {
@@ -281,9 +283,11 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
                 MediaSource mediaSource;
                 if (URLUtil.isHttpsUrl(url) || URLUtil.isHttpUrl(url)) {
                     mediaSource = new ProgressiveMediaSource.Factory(onlineDataSourceFactory)
+                            .setLoadErrorHandlingPolicy(insightCustomLoadErrorPolicy)
                             .createMediaSource(Uri.parse(url));
                 } else {
                     mediaSource = new ProgressiveMediaSource.Factory(offlineDataSourceFactory)
+                            .setLoadErrorHandlingPolicy(insightCustomLoadErrorPolicy)
                             .createMediaSource(Uri.parse(url));
                 }
                 concatenatingMediaSource.addMediaSource(mediaSource);
@@ -297,9 +301,11 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
             MediaSource mediaSource;
             if (URLUtil.isHttpsUrl(url) || URLUtil.isHttpUrl(url)) {
                 mediaSource = new ProgressiveMediaSource.Factory(onlineDataSourceFactory)
+                        .setLoadErrorHandlingPolicy(insightCustomLoadErrorPolicy)
                         .createMediaSource(Uri.parse(url));
             } else {
                 mediaSource = new ProgressiveMediaSource.Factory(offlineDataSourceFactory)
+                        .setLoadErrorHandlingPolicy(insightCustomLoadErrorPolicy)
                         .createMediaSource(Uri.parse(url));
             }
             player.prepare(mediaSource, true, false);

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
@@ -90,7 +90,6 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
     private ArrayList<AudioObject> audioObjects;
     private AudioObject audioObject;
     private Cache cache;
-    private InsightCustomLoadErrorPolicy insightCustomLoadErrorPolicy;
 
     @Nullable
     @Override
@@ -275,7 +274,7 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
         DataSource.Factory offlineDataSourceFactory = new DefaultDataSourceFactory(this, Util.getUserAgent(this.context, "exoPlayerLibrary"));
         DataSource.Factory onlineDataSourceFactory = new InsightCacheDataSourceFactory(this.context, cache);
         // playlist/single audio load
-        insightCustomLoadErrorPolicy = new InsightCustomLoadErrorPolicy();
+        InsightCustomLoadErrorPolicy insightCustomLoadErrorPolicy = new InsightCustomLoadErrorPolicy();
         if (this.playerMode == PlayerMode.PLAYLIST) {
             ConcatenatingMediaSource concatenatingMediaSource = new ConcatenatingMediaSource();
             for (AudioObject audioObject : audioObjects) {

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/InsightCustomLoadErrorPolicy.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/InsightCustomLoadErrorPolicy.java
@@ -1,0 +1,28 @@
+package danielr2001.audioplayer.audioplayers;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.upstream.DefaultLoadErrorHandlingPolicy;
+import com.google.android.exoplayer2.upstream.HttpDataSource;
+import java.io.IOException;
+
+public class InsightCustomLoadErrorPolicy extends DefaultLoadErrorHandlingPolicy {
+
+    @Override
+    public long getBlacklistDurationMsFor(int dataType, long loadDurationMs, IOException exception, int errorCount) {
+        return 0;
+    }
+
+    @Override
+    public long getRetryDelayMsFor(int dataType, long loadDurationMs, IOException exception, int errorCount) {
+        if (exception instanceof HttpDataSource.HttpDataSourceException) {
+            return 5000; // Retry every 5 seconds.
+        } else {
+            return C.TIME_UNSET; // Anything else is surfaced.
+        }
+    }
+
+    @Override
+    public int getMinimumLoadableRetryCount(int dataType) {
+        return Integer.MAX_VALUE;
+    }
+}


### PR DESCRIPTION
Fixed #2203 Add error policy to reconnect exoplayer

Reason of issue: ExoPlayer was not reconnecting and went to Idle state

Solution: Added Error policy to reconnect exoplayer

Side effect: No side effect